### PR TITLE
Feat/setup disconnection

### DIFF
--- a/src/main/java/it/polimi/ingsw/server/Match.java
+++ b/src/main/java/it/polimi/ingsw/server/Match.java
@@ -4,6 +4,7 @@ import it.polimi.ingsw.controller.Controller;
 import it.polimi.ingsw.controller.User;
 import it.polimi.ingsw.model.Game;
 import it.polimi.ingsw.utils.StatusMessages;
+import it.polimi.ingsw.utils.messages.ClientDisconnectMessage;
 import it.polimi.ingsw.utils.messages.DisconnectMessage;
 import it.polimi.ingsw.utils.networking.Connection;
 import it.polimi.ingsw.view.View;
@@ -120,9 +121,12 @@ public class Match implements Runnable {
      * @param nickname   the nickname chosen by the participants
      * @param connection the connection of the participant
      */
-    public void addParticipant(String nickname, Connection connection){
+    public void addParticipant(String nickname, Connection connection) {
         this.participantsNicknameToConnection.put(nickname, connection);
         virtualViews.add(new View(connection, nickname));
+        if (!connection.isActive()) {
+            virtualViews.get(virtualViews.size() - 1).updateFromClient(new ClientDisconnectMessage());
+        }
     }
 
     /**
@@ -136,6 +140,9 @@ public class Match implements Runnable {
 
         for (Map.Entry<String, Connection> participant : participants.entrySet()) {
             virtualViews.add(new View(participant.getValue(), participant.getKey()));
+            if (!participant.getValue().isActive()) {
+                virtualViews.get(virtualViews.size() - 1).updateFromClient(new ClientDisconnectMessage());
+            }
         }
     }
 

--- a/src/main/java/it/polimi/ingsw/server/Match.java
+++ b/src/main/java/it/polimi/ingsw/server/Match.java
@@ -47,6 +47,11 @@ public class Match implements Runnable {
      */
     private boolean isPlaying = true;
 
+    /**
+     * The match constructor.
+     *
+     * @param server the server hosting the match
+     */
     public Match(Server server) {
         this.server = server;
     }

--- a/src/main/java/it/polimi/ingsw/server/Match.java
+++ b/src/main/java/it/polimi/ingsw/server/Match.java
@@ -95,6 +95,10 @@ public class Match implements Runnable {
             //the controller observes the view
             virtualView.addObserver(controller, (obs, message) ->
                     ((Controller) obs).update(message));
+            //check if connection is still up, if not send a disconnection message to dismantle the game
+            if (!participantsNicknameToConnection.get(user.nickname).isActive()) {
+                virtualView.updateFromClient(new ClientDisconnectMessage());
+            }
         }
         //Start setup procedure
         model.setup();
@@ -124,9 +128,6 @@ public class Match implements Runnable {
     public void addParticipant(String nickname, Connection connection) {
         this.participantsNicknameToConnection.put(nickname, connection);
         virtualViews.add(new View(connection, nickname));
-        if (!connection.isActive()) {
-            virtualViews.get(virtualViews.size() - 1).updateFromClient(new ClientDisconnectMessage());
-        }
     }
 
     /**

--- a/src/main/java/it/polimi/ingsw/server/Match.java
+++ b/src/main/java/it/polimi/ingsw/server/Match.java
@@ -141,9 +141,6 @@ public class Match implements Runnable {
 
         for (Map.Entry<String, Connection> participant : participants.entrySet()) {
             virtualViews.add(new View(participant.getValue(), participant.getKey()));
-            if (!participant.getValue().isActive()) {
-                virtualViews.get(virtualViews.size() - 1).updateFromClient(new ClientDisconnectMessage());
-            }
         }
     }
 

--- a/src/main/java/it/polimi/ingsw/server/Server.java
+++ b/src/main/java/it/polimi/ingsw/server/Server.java
@@ -108,8 +108,8 @@ public class Server{
             ongoingMatches.add(match);
         }
             for (Connection connection : match.getParticipantsNicknameToConnection().values()) {
-                connection.removeObserver(handlers.get(connection));
                 synchronized (handlers) {
+                    connection.removeObserver(handlers.get(connection));
                     handlers.remove(connection);
                 }
             }

--- a/src/main/java/it/polimi/ingsw/server/Server.java
+++ b/src/main/java/it/polimi/ingsw/server/Server.java
@@ -107,16 +107,16 @@ public class Server{
         synchronized (ongoingMatches) {
             ongoingMatches.add(match);
         }
-        synchronized (handlers) {
             for (Connection connection : match.getParticipantsNicknameToConnection().values()) {
                 connection.removeObserver(handlers.get(connection));
-                handlers.remove(connection);
+                synchronized (handlers) {
+                    handlers.remove(connection);
+                }
             }
         }
-    }
 
     /**
-     * This method removes a Match instance from the ongoing matches
+     * This method removes a Match instance from the ongoing matches.
      *
      * @param match the match we need to remove
      */
@@ -127,6 +127,17 @@ public class Server{
         match.getParticipantsNicknameToConnection()
                 .keySet()
                 .forEach(lobbyBuilder::removeNickname);
+    }
+
+    /**
+     * This method removes a handler drom the handlers.
+     *
+     * @param connection the connection related to the handler
+     */
+    void removeHandler(Connection connection) {
+        synchronized (handlers) {
+            handlers.remove(connection);
+        }
     }
 
     /**

--- a/src/main/java/it/polimi/ingsw/server/Server.java
+++ b/src/main/java/it/polimi/ingsw/server/Server.java
@@ -130,7 +130,7 @@ public class Server{
     }
 
     /**
-     * This method removes a handler drom the handlers.
+     * This method removes a handler from the handlers.
      *
      * @param connection the connection related to the handler
      */

--- a/src/main/java/it/polimi/ingsw/server/ServerLobbyBuilder.java
+++ b/src/main/java/it/polimi/ingsw/server/ServerLobbyBuilder.java
@@ -4,10 +4,7 @@ import it.polimi.ingsw.config.ConfigParser;
 import it.polimi.ingsw.utils.StatusMessages;
 import it.polimi.ingsw.utils.networking.Connection;
 
-import java.util.AbstractMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -248,6 +245,12 @@ public class ServerLobbyBuilder {
                 participants.forEach(participant -> match.addParticipant(participant.getValue(), participant.getKey()));
 
                 server.submitMatch(match);
+            } else {
+                //otherwise put all the removed connections back in place
+                synchronized (lobbyRequestingConnections) {
+                    Collections.reverse(participants);
+                    participants.forEach(participant -> lobbyRequestingConnections.addFirst(participant.getKey()));
+                }
             }
         }
     }

--- a/src/main/java/it/polimi/ingsw/server/ServerLobbyBuilder.java
+++ b/src/main/java/it/polimi/ingsw/server/ServerLobbyBuilder.java
@@ -227,7 +227,6 @@ public class ServerLobbyBuilder {
                     }
                 }
                 //At this point we copy the necessary connections and nicknames to guarantee coherence after on
-
                 participants = lobbyRequestingConnections.subList(0, currentLobbyPlayerCount).stream()
                         .map(connection ->
                                 new AbstractMap.SimpleEntry<>(connection, registeredNicknames.get(connection))

--- a/src/main/java/it/polimi/ingsw/server/ServerLobbyBuilder.java
+++ b/src/main/java/it/polimi/ingsw/server/ServerLobbyBuilder.java
@@ -241,11 +241,13 @@ public class ServerLobbyBuilder {
                 }
             }
 
-            Match match = new Match(server);
+            if (participants.get(0).getKey().equals(firstConnection)) {
+                Match match = new Match(server);
 
-            participants.forEach(participant -> match.addParticipant(participant.getValue(), participant.getKey()));
+                participants.forEach(participant -> match.addParticipant(participant.getValue(), participant.getKey()));
 
-            server.submitMatch(match);
+                server.submitMatch(match);
+            }
         }
     }
 

--- a/src/main/java/it/polimi/ingsw/server/ServerLobbyBuilder.java
+++ b/src/main/java/it/polimi/ingsw/server/ServerLobbyBuilder.java
@@ -177,11 +177,11 @@ public class ServerLobbyBuilder {
                             Thread.currentThread().interrupt();
                         }
                     }
+                    //set a new first connection
+                    firstConnection = lobbyRequestingConnections.getFirst();
+                    //send continue message
+                    firstConnection.send(StatusMessages.CONTINUE);
                 }
-                //set a new first connection
-                firstConnection = lobbyRequestingConnections.getFirst();
-                //send continue message
-                firstConnection.send(StatusMessages.CONTINUE);
             }
             connection.close();
         }

--- a/src/main/java/it/polimi/ingsw/server/ServerLobbyBuilder.java
+++ b/src/main/java/it/polimi/ingsw/server/ServerLobbyBuilder.java
@@ -154,6 +154,7 @@ public class ServerLobbyBuilder {
      * @return true if there were no errors
      */
     public boolean handleDisconnection(Connection connection) {
+        connection.close();
         synchronized (lobbyRequestingConnections) {
             lobbyRequestingConnections.removeIf(requestingConnection -> requestingConnection.equals(connection));
         }
@@ -190,7 +191,7 @@ public class ServerLobbyBuilder {
                 }
             }
             synchronized(lobbyRequestingConnections){
-                while(lobbyRequestingConnections.size() < currentLobbyPlayerCount){
+                while (lobbyRequestingConnections.size() < currentLobbyPlayerCount) {
                     try {
                         lobbyRequestingConnections.wait();
                     } catch (InterruptedException e) {
@@ -200,9 +201,13 @@ public class ServerLobbyBuilder {
                 }
             }
 
+            //TODO sync this part
+            //this would be synchronized in the same block as above, a check if the first player
+            //was removed should be implemented.
+            //If true, then continue the cycle.
             Match match = new Match(server);
 
-            for(int i = 0; i < currentLobbyPlayerCount; i++){
+            for (int i = 0; i < currentLobbyPlayerCount; i++) {
                 Connection connection = lobbyRequestingConnections.removeFirst();
                 String nickname = registeredNicknames.get(connection);
                 match.addParticipant(nickname, connection);

--- a/src/main/java/it/polimi/ingsw/server/ServerLobbyBuilder.java
+++ b/src/main/java/it/polimi/ingsw/server/ServerLobbyBuilder.java
@@ -241,6 +241,7 @@ public class ServerLobbyBuilder {
                 }
             }
 
+            //if the first player didn't disconnect, then go ahead and create a match
             if (participants.get(0).getKey().equals(firstConnection)) {
                 Match match = new Match(server);
 

--- a/src/main/java/it/polimi/ingsw/utils/messages/ClientDisconnectMessage.java
+++ b/src/main/java/it/polimi/ingsw/utils/messages/ClientDisconnectMessage.java
@@ -2,13 +2,34 @@ package it.polimi.ingsw.utils.messages;
 
 import it.polimi.ingsw.controller.Controller;
 import it.polimi.ingsw.controller.User;
+import it.polimi.ingsw.server.ServerConnectionSetupHandler;
 import it.polimi.ingsw.utils.networking.ControllerHandleable;
+import it.polimi.ingsw.utils.networking.ServerHandleable;
 import it.polimi.ingsw.view.View;
 
-public class ClientDisconnectMessage implements DisconnectMessage, ClientMessage, ControllerHandleable {
+public class ClientDisconnectMessage implements DisconnectMessage, ClientMessage, ControllerHandleable, ServerHandleable {
+    /**
+     * Handles the interaction with the controller.
+     *
+     * @param handler the controller
+     * @param view    the view
+     * @param user    the user
+     * @return true if there were no errors.
+     */
     @Override
     public boolean handleTransmittable(Controller handler, View view, User user) {
         handler.dispatchDrawAction(view, user);
         return true;
+    }
+
+    /**
+     * Handles the interaction with the server.
+     *
+     * @param handler the handler
+     * @return true if there were no errors.
+     */
+    @Override
+    public boolean handleTransmittable(ServerConnectionSetupHandler handler) {
+        return handler.getLobbyBuilder().handleDisconnection(handler.getConnection());
     }
 }

--- a/src/main/java/it/polimi/ingsw/view/View.java
+++ b/src/main/java/it/polimi/ingsw/view/View.java
@@ -27,8 +27,7 @@ public class View extends LambdaObservable<ViewClientMessage> implements LambdaO
      */
     public void updateFromClient(Transmittable message) {
         this.notify(
-                new ViewClientMessage((ClientMessage) message, this, this.getUser()),
-                true
+                new ViewClientMessage((ClientMessage) message, this, this.getUser())
         );
     }
 

--- a/src/main/java/it/polimi/ingsw/view/View.java
+++ b/src/main/java/it/polimi/ingsw/view/View.java
@@ -26,7 +26,10 @@ public class View extends LambdaObservable<ViewClientMessage> implements LambdaO
      * @param message a message coming from the client
      */
     public void updateFromClient(Transmittable message) {
-        this.notify(new ViewClientMessage((ClientMessage) message, this, this.getUser()));
+        this.notify(
+                new ViewClientMessage((ClientMessage) message, this, this.getUser()),
+                true
+        );
     }
 
     /**

--- a/src/test/java/it/polimi/ingsw/server/MatchTest.java
+++ b/src/test/java/it/polimi/ingsw/server/MatchTest.java
@@ -34,6 +34,8 @@ class MatchTest {
         myMap.put(nicknames[0], mock(Connection.class));
         myMap.put(nicknames[1], mock(Connection.class));
         myMap.put(nicknames[2], mock(Connection.class));
+        //establish behaviour
+        myMap.forEach((nickname, connection) -> when(connection.isActive()).thenReturn(true));
         //initialize a match
         Match myMatch = new Match(myServer);
         //now try first to add as a LinkedHashMap

--- a/src/test/java/it/polimi/ingsw/server/ServerTest.java
+++ b/src/test/java/it/polimi/ingsw/server/ServerTest.java
@@ -19,8 +19,7 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 
 public class ServerTest {
     Server server = null;
@@ -47,6 +46,7 @@ public class ServerTest {
     void mockConnections(){
         for(int j = 0; j < 3; j++){
             Connection mock = mock(Connection.class);
+            when(mock.isActive()).thenReturn(true);
             LinkedList<Transmittable> q = new LinkedList<>();
             ServerConnectionSetupHandler ch = new ServerConnectionSetupHandler(server, mock);
             doAnswer(i -> q.add((Transmittable) i.getArguments()[0]))

--- a/src/test/java/it/polimi/ingsw/server/ServerTest.java
+++ b/src/test/java/it/polimi/ingsw/server/ServerTest.java
@@ -268,8 +268,6 @@ public class ServerTest {
 
         t.start();
 
-        await().until(() -> !t.isAlive()); //Thread should terminate here
-
         setCheckNickname(1, "Rene Ferretti");
         setCheckJoinLobby(1, false, 0);
 
@@ -289,6 +287,7 @@ public class ServerTest {
 
         s.start();
 
+        await().until(() -> !t.isAlive()); //Thread should terminate here
         await().until(() -> !s.isAlive()); //Thread should terminate here
 
         await().until(() -> server.getOngoingMatches().size() > 0);
@@ -296,5 +295,7 @@ public class ServerTest {
         assertEquals(1, server.getOngoingMatches().size()); //There should be one match
         //Check match
         Match match = server.getOngoingMatches().get(0);
+        assertEquals(3, match.getParticipantsNicknameToConnection().size());
+        assertEquals("Rene Ferretti", match.getVirtualViews().get(0).getUser().nickname);
     }
 }

--- a/src/test/java/it/polimi/ingsw/server/ServerTest.java
+++ b/src/test/java/it/polimi/ingsw/server/ServerTest.java
@@ -240,7 +240,7 @@ public class ServerTest {
 
         assertEquals(2, lobbyBuilder.getCurrentLobbyPlayerCount());
 
-        setCheckNickname(2, "Stanis");
+        setCheckNickname(2, "Boris");
         setCheckJoinLobby(2, false, 0);
 
         assertEquals(1, server.getOngoingMatches().size()); //There should be one match

--- a/src/test/java/it/polimi/ingsw/server/ServerTest.java
+++ b/src/test/java/it/polimi/ingsw/server/ServerTest.java
@@ -188,7 +188,7 @@ public class ServerTest {
     }
 
     @Test
-    void threePlayersJoining1() {
+    void threePlayersJoining() {
         mockConnections();
 
         assertEquals(0, server.getOngoingMatches().size()); //There should be no matches

--- a/src/test/java/it/polimi/ingsw/server/ServerTest.java
+++ b/src/test/java/it/polimi/ingsw/server/ServerTest.java
@@ -65,9 +65,9 @@ public class ServerTest {
         server.shutdown();
     }
 
-    Transmittable waitForMessage(Queue queue){
+    Transmittable waitForMessage(Queue<Transmittable> queue) {
         await().until(() -> queue.size() > 0);
-        return (Transmittable)queue.remove();
+        return queue.remove();
     }
 
     void setCheckNickname(int index, String nickname){
@@ -92,7 +92,7 @@ public class ServerTest {
     }
 
     @Test
-    void twoPlayersJoining1() throws InterruptedException {
+    void twoPlayersJoining1() {
         Transmittable message = null;
         mockConnections();
 
@@ -127,16 +127,14 @@ public class ServerTest {
         //Player1 and Player2 get inserted into the match
         //Player3 should be inserted into the next lobby and is requested a playerCount
 
-        Transmittable message = null;
+        Transmittable message;
         mockConnections();
 
         assertEquals(0, server.getOngoingMatches().size()); //There should be no matches
 
         setCheckNickname(0, "Boris");
 
-        Thread t = new Thread(()-> {
-            connHandlers[0].update(new ClientJoinLobbyMessage());
-        });
+        Thread t = new Thread(() -> connHandlers[0].update(new ClientJoinLobbyMessage()));
         t.start();
 
         //Player1 is requested a playerCount
@@ -152,18 +150,11 @@ public class ServerTest {
         message = waitForMessage(queues[1]);
         assertEquals(StatusMessages.CLIENT_ERROR, message); //Nickname should get rejected
 
-        connHandlers[1].update(new ClientSetNicknameMessage("Rene Ferretti"));
+        setCheckNickname(1, "Rene Ferretti");
 
-        message = waitForMessage(queues[1]);
-        assertEquals(StatusMessages.OK, message); //Nickname should get accepted
+        Thread t1 = new Thread(() -> connHandlers[1].update(new ClientJoinLobbyMessage()));
 
-        Thread t1 = new Thread( () -> {
-            connHandlers[1].update(new ClientJoinLobbyMessage());
-        });
-
-        Thread t2 = new Thread( () -> {
-            connHandlers[2].update(new ClientJoinLobbyMessage());
-        });
+        Thread t2 = new Thread(() -> connHandlers[2].update(new ClientJoinLobbyMessage()));
 
         t1.start();
         t2.start();
@@ -200,8 +191,7 @@ public class ServerTest {
     }
 
     @Test
-    void threePlayersJoining1() throws InterruptedException {
-        Transmittable message = null;
+    void threePlayersJoining1() {
         mockConnections();
 
         assertEquals(0, server.getOngoingMatches().size()); //There should be no matches


### PR DESCRIPTION
Complete implementation of the disconnection in the setup phase.
The implementation should be deadlocks and synchronization bugs free, but please focus on finding them during the review. The implementation tries to keep the non-disconnected players in-game as long as it can, but if a match gets created then they should receive a disconnection message.
Sorry for the delay guys.
```
 /\_/\
( o.o )
 > ^ <
```
Fixes #5 